### PR TITLE
fix:git ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 out
+.DS_Store
 
 # Ignore macOS build files
 *.dmg


### PR DESCRIPTION
Added .DS_Store to .gitignore to prevent them from being tracked in the repository.